### PR TITLE
Fix cron for clearing old logs

### DIFF
--- a/lib/cron/index.js
+++ b/lib/cron/index.js
@@ -20,7 +20,15 @@ exports.load = function (callback) {
         job.on('tick-complete', handlers.tickComplete.bind(job));
       });
 
-      callback(null, jobs);
+      cmaster.startJobs(function(err) {
+        if (err) {
+          callback(
+            new VError(err, 'failed to start cron-master jobs'),
+            null);
+        } else {
+          callback(null, jobs);
+        }
+      });
     }
   });
 };

--- a/lib/cron/index.test.js
+++ b/lib/cron/index.test.js
@@ -8,14 +8,17 @@ var proxyquire = require('proxyquire')
 describe(__filename, function () {
 
   var mod
-    , loadStub;
+    , loadStub
+    , startStub;
 
   beforeEach(function () {
     loadStub = sinon.stub();
+    startStub = sinon.stub();
 
     mod = proxyquire('./index.js', {
       'cron-master': {
-        loadJobs: loadStub
+        loadJobs: loadStub,
+        startJobs: startStub
       }
     });
   });
@@ -23,23 +26,41 @@ describe(__filename, function () {
   describe('#load', function () {
     it('should load jobs', function () {
       var jobs = [new EventEmitter()];
-      
-      loadStub.callsArgWith(1, null, jobs);
+
+      loadStub.yields(null, jobs);
+      startStub.yields(null);
 
       mod.load(function (err, jerbs) {
         expect(err).to.not.exist;
+        expect(loadStub.callCount).to.eql(1);
+        expect(startStub.callCount).to.eql(1);
         expect(jerbs).to.deep.equal(jobs);
       });
     });
 
-    it('should handle an error', function () {
-      loadStub.callsArgWith(1, new Error('oh noes!'), null);
+    it('should handle an error in loading jobs', function () {
+      loadStub.yields(new Error('oh noes!'), null);
 
       mod.load(function (err, jerbs) {
         expect(jerbs).to.not.exist;
         expect(err).to.exit;
-        expect(err.toString()).to.contain('failed to load cron-master jobs from');
-        expect(err.toString()).to.contain('oh noes');
+        expect(err.message).to.contain('failed to load cron-master jobs from');
+        expect(err.message).to.contain('oh noes');
+        expect(startStub.callCount).to.eql(0);
+      });
+    });
+
+    it('should handle an error in starting jobs', function () {
+      loadStub.yields(null, []);
+      startStub.yields(new Error('oh noes!'), null);
+
+      mod.load(function (err, jerbs) {
+        expect(jerbs).to.not.exist;
+        expect(err).to.exit;
+        expect(err.message).to.contain('failed to start cron-master jobs');
+        expect(err.message).to.contain('oh noes');
+        expect(loadStub.callCount).to.eql(1);
+        expect(startStub.callCount).to.eql(1);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tke-logger",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A thin wrapper around bunyan that provides sensible logging defaults",
   "main": "lib/logger.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "bunyan": "^1.7.1",
-    "cron-master": "^0.2.0",
+    "cron-master": "^0.3.0",
     "lodash.map": "^4.2.1",
     "mongo-utils": "git+https://github.com/evanshortiss/mongo-utils.git#0.2.0",
     "verror": "^1.6.1",


### PR DESCRIPTION
Forgot to call `startJobs()`

Also updated to latest cron-master
